### PR TITLE
Remove "@" from speakers' Twitter profiles

### DIFF
--- a/app/Models/Speaker.php
+++ b/app/Models/Speaker.php
@@ -42,7 +42,7 @@ class Speaker extends Model
     {
         $value = str_replace(' ', '', $value);
         if (strlen($value) and !starts_with($value, '@')) {
-            return $this->attributes['twitter_name'] = '@' . $value;
+            return $this->attributes['twitter_name'] = $value;
         }
 
         return $this->attributes['twitter_name'] = $value;


### PR DESCRIPTION
Minor fix regarding the "user not found" error thrown by the Twitter for Android app, when clicked on the Twitter profile links of speakers. Integration server keeps speakers' handles with "@" in the beginning on the database, which somehow confuses the Twitter for Android.

Twitter for iOS and web view is working flawlessly with or without the "@", so I'm suggesting it is not necessary to enforce a hard-coded "@" on the handles.