### PR TITLE
Change zizaco/entrust version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "intervention/image": "dev-master",
         "davejamesmiller/laravel-breadcrumbs": "^3.0",
         "yajra/laravel-datatables-oracle": "~6.0",
-        "zizaco/entrust": "5.2.x-dev",
+        "zizaco/entrust": "dev-master",
         "fzaninotto/faker": "~1.4",
         "zircote/swagger-php": "^2.0"
     },


### PR DESCRIPTION
For removing 'This cache store does not support tagging' error.
see https://github.com/Zizaco/entrust/issues/612