### PR TITLE
Move and use image logic (saving images, deleting images) from ImageHelper helper

### DIFF
--- a/app/Helpers/ImageHelper.php
+++ b/app/Helpers/ImageHelper.php
@@ -73,4 +73,21 @@ class ImageHelper
 
         return true;
     }
+
+    /**
+     * Delete image by path
+     *
+     * @param string $path
+     *
+     * @return mixed
+     */
+    public static function deleteImage($path)
+    {
+        $realPath = public_path($path);
+        if (File::exists($realPath)) {
+            return File::delete($realPath);
+        }
+
+        return true;
+    }
 }

--- a/app/Repositories/BaseRepository.php
+++ b/app/Repositories/BaseRepository.php
@@ -6,7 +6,6 @@ use Bosnadev\Repositories\Contracts\RepositoryInterface;
 use Bosnadev\Repositories\Eloquent\Repository;
 use Carbon\Carbon;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Illuminate\Support\Facades\File;
 use App\Helpers\ImageHelper;
 
 class BaseRepository extends Repository implements RepositoryInterface
@@ -102,12 +101,7 @@ class BaseRepository extends Repository implements RepositoryInterface
      */
     public function deleteImage($path)
     {
-        $realPath = public_path($path);
-        if (File::exists($realPath)) {
-            return File::delete($realPath);
-        }
-
-        return true;
+        return ImageHelper::deleteImage($path);
     }
 
     /**

--- a/app/Repositories/BaseRepository.php
+++ b/app/Repositories/BaseRepository.php
@@ -5,11 +5,9 @@ namespace App\Repositories;
 use Bosnadev\Repositories\Contracts\RepositoryInterface;
 use Bosnadev\Repositories\Eloquent\Repository;
 use Carbon\Carbon;
-use Mockery\CountValidator\Exception;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Intervention\Image\Facades\Image;
 use Illuminate\Support\Facades\File;
-use Symfony\Component\HttpFoundation\File\Exception\FileException;
+use App\Helpers\ImageHelper;
 
 class BaseRepository extends Repository implements RepositoryInterface
 {
@@ -92,36 +90,7 @@ class BaseRepository extends Repository implements RepositoryInterface
      */
     public function saveImage($image, $directory = '', $size = ['width' => 800, 'height' => 600])
     {
-        try {
-            $directory = str_replace('.', DIRECTORY_SEPARATOR, $directory);
-            $imageRealPath = $image->getRealPath();
-            $timestamp = Carbon::now()->format('Y-m-d-H-i-s');
-            $fileName = pathinfo($image->getClientOriginalName(), PATHINFO_FILENAME);
-            $extension = pathinfo($image->getClientOriginalName(), PATHINFO_EXTENSION);
-            $thumbName = $timestamp . '-' . str_slug($fileName, "-") . '.' . $extension;
-            
-            $img = Image::make($imageRealPath);
-            if ($img->width() > $size['width']) {
-                $img->resize(intval($size['width']), null, function ($constraint) {
-                    $constraint->aspectRatio();
-                });
-            } elseif ($img->height() > $size['height']) {
-                $img->resize(null, intval($size['height']), function ($constraint) {
-                    $constraint->aspectRatio();
-                });
-            }
-            $pathToDirectory = DIRECTORY_SEPARATOR . 'uploads' . DIRECTORY_SEPARATOR . $directory . DIRECTORY_SEPARATOR;
-            if (!$this->checkAndMakeDirectory($pathToDirectory)) {
-                throw new FileException(sprintf('Unable to create the "%s" directory', $pathToDirectory));
-            }
-
-            $path = $pathToDirectory . $thumbName;
-            $img->save(public_path() . $path);
-
-            return $path;
-        } catch (Exception $e) {
-            return false;
-        }
+        return ImageHelper::saveImage($image, $directory,  $size);
     }
 
     /**
@@ -136,23 +105,6 @@ class BaseRepository extends Repository implements RepositoryInterface
         $realPath = public_path($path);
         if (File::exists($realPath)) {
             return File::delete($realPath);
-        }
-
-        return true;
-    }
-
-    /**
-     * Create directory if it don't exist
-     *
-     * @param string $path
-     *
-     * @return bool
-     */
-    protected function checkAndMakeDirectory($path)
-    {
-        $realPath = public_path($path);
-        if (!File::exists($realPath)) {
-            return File::makeDirectory($realPath, 0775, true);
         }
 
         return true;


### PR DESCRIPTION
- BaseRepository uses the same code than ImageHelper to store a new image (so why to replicate the code and not to use the helper?)
-Seems correct to put image deletion logic also into the helper (it is not being used from anywhere else than BaseRepository but it could end in the same code replication problem with image saving)